### PR TITLE
Remove automountServiceAccountToken field for agents daemon sets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.2.0
 	github.com/gardener/gardener v1.52.2
-	github.com/gardener/network-problem-detector v0.5.0
+	github.com/gardener/network-problem-detector v0.7.0
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.20.0

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/gardener/hvpa-controller/api v0.5.0 h1:f4F3O7YUrenwh4S3TgPREPiB287Jjj
 github.com/gardener/hvpa-controller/api v0.5.0/go.mod h1:QQl3ELkCaki+8RhXl0FZMfvnm0WCGwGJlGmrxJj6lvM=
 github.com/gardener/machine-controller-manager v0.45.0 h1:rpf0PHRXJMGY93oMruNP+tnMawKJXhhzCACyNJsT8Lo=
 github.com/gardener/machine-controller-manager v0.45.0/go.mod h1:+4j/6ab3jqbM6tM6FPtlajYgaJHM0xZ44ErOjCBlsP8=
-github.com/gardener/network-problem-detector v0.5.0 h1:wRN8Cou6D8aKTczRViA+QH4BJAC4YT6Cv5GM5LvlbXs=
-github.com/gardener/network-problem-detector v0.5.0/go.mod h1:AO70yeFVpw0wSSmNHwxzF6vRUS1hMgmEsYTpttwb+nA=
+github.com/gardener/network-problem-detector v0.7.0 h1:QQGJFskwAykpRXwsu3KZf4Qs/IM50bD7qvX9ZDEFHOs=
+github.com/gardener/network-problem-detector v0.7.0/go.mod h1:AO70yeFVpw0wSSmNHwxzF6vRUS1hMgmEsYTpttwb+nA=
 github.com/getkin/kin-openapi v0.76.0/go.mod h1:660oXbgy5JFMKreazJaQTw7o+X00qeSyhcnluiMv+Xg=
 github.com/getsentry/raven-go v0.2.0/go.mod h1:KungGk8q33+aIAZUIVWZDr2OfAEBsO49PX4NzFV5kcQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/pkg/controller/lifecycle/actuator.go
+++ b/pkg/controller/lifecycle/actuator.go
@@ -269,6 +269,8 @@ func (a *actuator) getShootAgentResources(defaultPeriod time.Duration, pingEnabl
 			"networking.gardener.cloud/to-dns":              "allowed",
 			"networking.gardener.cloud/to-from-nwpd-agents": "allowed",
 		},
+		// projected service account token is provided by the resource manager
+		DisableAutomountServiceAccountTokenForAgents: true,
 	}
 	if k8sExporter != nil && k8sExporter.Enabled {
 		deployConfig.K8sExporterEnabled = true

--- a/vendor/github.com/gardener/network-problem-detector/pkg/common/utils.go
+++ b/vendor/github.com/gardener/network-problem-detector/pkg/common/utils.go
@@ -48,3 +48,17 @@ func (s StringSet) ToSortedArray() []string {
 func FormatAsUTC(t time.Time) string {
 	return t.UTC().Format("2006-01-02T15:04:05Z")
 }
+
+// MergeMaps merges two maps. If key is contained in both maps, the value of the second map is used.
+func MergeMaps(map1, map2 map[string]string) map[string]string {
+	result := map[string]string{}
+
+	for k, v := range map1 {
+		result[k] = v
+	}
+
+	for k, v := range map2 {
+		result[k] = v
+	}
+	return result
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -149,7 +149,7 @@ github.com/gardener/hvpa-controller/api/v1alpha1
 ## explicit; go 1.17
 github.com/gardener/machine-controller-manager/pkg/apis/machine
 github.com/gardener/machine-controller-manager/pkg/apis/machine/v1alpha1
-# github.com/gardener/network-problem-detector v0.5.0
+# github.com/gardener/network-problem-detector v0.7.0
 ## explicit; go 1.18
 github.com/gardener/network-problem-detector/pkg/common
 github.com/gardener/network-problem-detector/pkg/common/config


### PR DESCRIPTION
**What this PR does / why we need it**:
Disable automountServiceAccountToken for agents daemon sets to to work correctly
with the [auto mounting of projected serviceaccount tokens feature](https://github.com/gardener/gardener/blob/eb8400a2961400a8b984252a76eb546ea44432fd/docs/concepts/resource-manager.md#auto-mounting-projected-serviceaccount-tokens)

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Remove automountServiceAccountToken field for agents daemon sets
```
