### PR TITLE
Add responsibles for components and cleanup old snapshot versions.

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -7,6 +7,12 @@ gardener-extension-shoot-networking-problemdetector:
   base_definition:
     repo: ~
     traits:
+      component_descriptor:
+        component_labels:
+        - name: 'cloud.gardener.cnudie/responsibles'
+          value:
+          - type: 'codeowners'
+        retention_policy: 'clean-snapshots'
       version:
         preprocess: 'inject-commit-hash'
       publish:
@@ -28,15 +34,12 @@ gardener-extension-shoot-networking-problemdetector:
   jobs:
     head-update:
       traits:
-        component_descriptor:
-          retention_policy: 'clean-snapshots'
         draft_release: ~
         options:
           public_build_logs: true
     pull-request:
       traits:
         pull-request: ~
-        component_descriptor: ~
         options:
           public_build_logs: true
     release:
@@ -53,7 +56,6 @@ gardener-extension-shoot-networking-problemdetector:
             internal_scp_workspace:
               channel_name: 'C9CEBQPGE' #sap-tech-gardener
               slack_cfg_name: 'scp_workspace'
-        component_descriptor: ~
         publish:
           dockerimages:
             gardener-extension-shoot-networking-problemdetector:


### PR DESCRIPTION
**What this PR does / why we need it**:
Add responsibles for components and cleanup old snapshot versions.

Furthermore, remove duplication in the build steps by moving the definition to the base.

**Which issue(s) this PR fixes**:
None.

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
