### PR TITLE
Port resource id to 0.14

### DIFF
--- a/charts/images.yaml
+++ b/charts/images.yaml
@@ -5,10 +5,14 @@
 ---
 images:
 - name: network-problem-detector-agent
+  resourceId:
+    name: network-problem-detector
   sourceRepository: github.com/gardener/network-problem-detector
   repository: eu.gcr.io/gardener-project/gardener/network-problem-detector
   tag: "v0.13.0"
 - name: network-problem-detector-controller
   sourceRepository: github.com/gardener/network-problem-detector
+  resourceId:
+    name: network-problem-detector
   repository: eu.gcr.io/gardener-project/gardener/network-problem-detector
   tag: "v0.13.0"


### PR DESCRIPTION
**How to categorize this PR?**
/area delivery
 /kind cleanup

**What this PR does / why we need it**:

[Component-CLI](https://github.com/gardener/component-cli) has has been deprecated, and is no longer actively maintained. Considering it contains a lot of custom and Gardener-specific logic for translating `charts/images.yaml` into component-descriptors, said logic was ported into default pipeline template at [cc-utils](https://github.com/gardener/cc-utils). In order to also somewhat simplify the implementation, resolution of referenced component-descriptors and implicity resource-matching was removed. There are some few cases where local resource-names and remote resources-names do not match. In those cases, an additional `resourceId`-Attribute needs to be added. `Component-CLI` will silently ignore/discard this new attribute, thus this change can already be accepted prior to switching from component-cli to its re-implementation.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
NONE