### PR TITLE
bunp builder image to golang:1.20.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 ############# builder
-FROM golang:1.20.2 AS builder
+FROM golang:1.20.4 AS builder
 
 WORKDIR /go/src/github.com/gardener/gardener-extension-shoot-networking-problemdetector
 COPY . .


### PR DESCRIPTION
**What this PR does / why we need it**:
Bump builder image to golang:1.20.4

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Bump builder image from `golang:1.20.2` to `golang:1.20.4`
```
