### PR TITLE
move network-problem-detector to observability

### DIFF
--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -10,6 +10,7 @@ import (
 
 	healthcheckconfig "github.com/gardener/gardener/extensions/pkg/apis/config"
 	"github.com/gardener/gardener/extensions/pkg/controller/healthcheck"
+	"github.com/gardener/gardener/extensions/pkg/controller/healthcheck/general"
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	extensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -40,7 +41,16 @@ func RegisterHealthChecks(ctx context.Context, mgr manager.Manager, opts healthc
 		mgr,
 		opts,
 		nil,
-		[]healthcheck.ConditionTypeToHealthCheck{},
+		[]healthcheck.ConditionTypeToHealthCheck{
+			{
+				ConditionType: string(gardencorev1beta1.ShootObservabilityComponentsHealthy),
+				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNamesControllerShoot),
+			},
+			{
+				ConditionType: string(gardencorev1beta1.ShootObservabilityComponentsHealthy),
+				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNamesAgentShoot),
+			},
+		},
 		sets.New[gardencorev1beta1.ConditionType](),
 	)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
Extension network-problem-detector registers health check condition for `SystemComponentsHealthy`. 
To provide a more accurate representation of system health and reduce the frequency of SystemComponentsUnHealthy alert, this PR will move network-problem-detector extension check to `ObservabilityComponentsHealthy`

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
