### PR TITLE
Correct NWPD datasource name

### DIFF
--- a/charts/internal/shoot-network-problem-detector-controller-seed/nwpd-dashboard.json
+++ b/charts/internal/shoot-network-problem-detector-controller-seed/nwpd-dashboard.json
@@ -3,7 +3,7 @@
     "list": [
       {
         "builtIn": 1,
-        "datasource": "-- Grafana --",
+        "datasource": "-- Plutono --",
         "enable": true,
         "hide": true,
         "iconColor": "rgba(0, 211, 255, 1)",

--- a/charts/internal/shoot-network-problem-detector-controller-seed/templates/scrapeconfig.yaml
+++ b/charts/internal/shoot-network-problem-detector-controller-seed/templates/scrapeconfig.yaml
@@ -35,16 +35,12 @@ spec:
     - __name__
     action: keep
     regex: nwpd_.+
-  - sourceLabels:
-    - namespace
-    action: keep
-    regex: kube-system
   relabelings:
   - action: replace
     replacement: network-problem-detector-agents
     targetLabel: job
-  - sourceLabels: [__meta_kubernetes_service_name,__meta_kubernetes_endpoint_port_name,__meta_kubernetes_namespace]
-    regex: network-problem-detector-(pod|host);metrics;kube-system
+  - sourceLabels: [__meta_kubernetes_service_name,__meta_kubernetes_endpoint_port_name]
+    regex: network-problem-detector-(pod|host);metrics
     action: keep
   - action: labelmap
     regex: __meta_kubernetes_pod_label_(.+)


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR corrects the dashboard datasource, as otherwise the dashboard cannot be loaded.

**Which issue(s) this PR fixes**:
NWPD dashboard fails to load because of non-existing datasource.
<img width="423" alt="Screenshot 2024-05-31 at 12 56 09" src="https://github.com/gardener/gardener-extension-shoot-networking-problemdetector/assets/119592402/7e721094-513f-4d78-b371-71c3fcbd5c36">

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Correct NWPD dashboard datasource value.
```
