### PR TITLE
Publish Helm charts as OCI artifacts

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -3,6 +3,18 @@
 # SPDX-License-Identifier: Apache-2.0
 
 gardener-extension-shoot-networking-problemdetector:
+  templates:
+    helmcharts:
+    - &shoot-networking-problemdetector
+      name: shoot-networking-problemdetector
+      dir: charts/gardener-extension-shoot-networking-problemdetector
+      registry: europe-docker.pkg.dev/gardener-project/snapshots/charts/gardener/extensions
+      mappings:
+      - ref: ocm-resource:gardener-extension-shoot-networking-problemdetector.repository
+        attribute: image.repository
+      - ref: ocm-resource:gardener-extension-shoot-networking-problemdetector.tag
+        attribute: image.tag
+
   base_definition:
     traits:
       component_descriptor:
@@ -38,6 +50,9 @@ gardener-extension-shoot-networking-problemdetector:
             - repository: europe-docker.pkg.dev/gardener-project/releases
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *shoot-networking-problemdetector
     pull-request:
       traits:
         pull-request: ~
@@ -46,6 +61,9 @@ gardener-extension-shoot-networking-problemdetector:
             - repository: europe-docker.pkg.dev/gardener-project/releases
         options:
           public_build_logs: true
+        publish:
+          helmcharts:
+          - *shoot-networking-problemdetector
     release:
       traits:
         version:
@@ -67,3 +85,6 @@ gardener-extension-shoot-networking-problemdetector:
             gardener-extension-shoot-networking-problemdetector:
               image: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/shoot-networking-problemdetector
               tag_as_latest: true
+          helmcharts:
+          - <<: *shoot-networking-problemdetector
+            registry: europe-docker.pkg.dev/gardener-project/releases/charts/gardener/extensions


### PR DESCRIPTION
/area delivery
/kind enhancement

**What this PR does / why we need it**:
We should start publishing Helm charts as OCI artifacts that we can deploy them as `Extension` in the future (see https://github.com/gardener/gardener/issues/9635).

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature operator
Helm charts of extension and admission controller are published as OCI artifacts now.
```
