### PR TITLE
Add verify step to pipeline definition

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -23,6 +23,9 @@ gardener-extension-shoot-networking-problemdetector:
           policy: skip
           comment: |
             we use gosec for sast scanning. See attached log.
+    steps:
+      verify:
+        image: 'golang:1.23.2'
     traits:
       component_descriptor:
         ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots


### PR DESCRIPTION
**What this PR does / why we need it**:

Add verify step to pipeline definition.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

The verify step has been removed from `refs/meta/ci` to make it more obvious.

This is an addon to https://github.com/gardener/gardener-extension-shoot-networking-problemdetector/pull/184.

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
