### PR TITLE
Remove `adjust-install-gosec` Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,18 +89,12 @@ generate: $(CONTROLLER_GEN) $(GEN_CRD_API_REFERENCE_DOCS) $(HELM) $(MOCKGEN) $(Y
 format: $(GOIMPORTS) $(GOIMPORTSREVISER)
 	@bash $(GARDENER_HACK_DIR)/format.sh ./cmd ./pkg ./test
 
-# TODO(scheererj): Remove once https://github.com/gardener/gardener/pull/10642 is available as release.
-TOOLS_PKG_PATH := $(shell go list -tags tools -f '{{ .Dir }}' github.com/gardener/gardener/hack/tools 2>/dev/null)
-.PHONY: adjust-install-gosec.sh
-adjust-install-gosec.sh:
-	@chmod +xw $(TOOLS_PKG_PATH)/install-gosec.sh
-
 .PHONY: sast
-sast: adjust-install-gosec.sh $(GOSEC)
+sast: $(GOSEC)
 	@./hack/sast.sh
 
 .PHONY: sast-report
-sast-report: adjust-install-gosec.sh $(GOSEC)
+sast-report: $(GOSEC)
 	@./hack/sast.sh --gosec-report true
 
 .PHONY: test


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove `adjust-install-gosec` Makefile target as not needed anymore.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
