### PR TITLE
Modify healthcheck to check the `ManagedResourceNamesControllerSeed`

### DIFF
--- a/pkg/controller/healthcheck/add.go
+++ b/pkg/controller/healthcheck/add.go
@@ -43,11 +43,7 @@ func RegisterHealthChecks(ctx context.Context, mgr manager.Manager, opts healthc
 		[]healthcheck.ConditionTypeToHealthCheck{
 			{
 				ConditionType: string(gardencorev1beta1.ShootObservabilityComponentsHealthy),
-				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNamesControllerShoot),
-			},
-			{
-				ConditionType: string(gardencorev1beta1.ShootObservabilityComponentsHealthy),
-				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNamesAgentShoot),
+				HealthCheck:   general.CheckManagedResource(constants.ManagedResourceNamesControllerSeed),
 			},
 		},
 		sets.New[gardencorev1beta1.ConditionType](),

--- a/test/integration/healthcheck/test.go
+++ b/test/integration/healthcheck/test.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("Extension-shoot-networking-problemdetector integration 
 	ginkgo.Context("Extension", func() {
 		ginkgo.Context("Condition type: ShootSystemComponentsHealthy", func() {
 			f.Serial().Release().CIt(fmt.Sprintf("Extension CRD should contain unhealthy condition due to ManagedResource '%s' is unhealthy", constants.ManagedResourceNamesAgentShoot), func(ctx context.Context) {
-				err := healthcheckoperation.ExtensionHealthCheckWithManagedResource(ctx, timeout, f, "shoot-networking-problemdetector", constants.ManagedResourceNamesAgentShoot, gardencorev1beta1.ShootSystemComponentsHealthy)
+				err := healthcheckoperation.ExtensionHealthCheckWithManagedResource(ctx, timeout, f, "shoot-networking-problemdetector", constants.ManagedResourceNamesControllerSeed, gardencorev1beta1.ShootSystemComponentsHealthy)
 				framework.ExpectNoError(err)
 			}, timeout)
 		})

--- a/test/integration/healthcheck/test.go
+++ b/test/integration/healthcheck/test.go
@@ -38,7 +38,7 @@ var _ = ginkgo.Describe("Extension-shoot-networking-problemdetector integration 
 	ginkgo.Context("Extension", func() {
 		ginkgo.Context("Condition type: ShootSystemComponentsHealthy", func() {
 			f.Serial().Release().CIt(fmt.Sprintf("Extension CRD should contain unhealthy condition due to ManagedResource '%s' is unhealthy", constants.ManagedResourceNamesAgentShoot), func(ctx context.Context) {
-				err := healthcheckoperation.ExtensionHealthCheckWithManagedResource(ctx, timeout, f, "shoot-networking-problemdetector", constants.ManagedResourceNamesControllerSeed, gardencorev1beta1.ShootSystemComponentsHealthy)
+				err := healthcheckoperation.ExtensionHealthCheckWithManagedResource(ctx, timeout, f, "shoot-networking-problemdetector", constants.ManagedResourceNamesControllerSeed, gardencorev1beta1.ShootObservabilityComponentsHealthy)
 				framework.ExpectNoError(err)
 			}, timeout)
 		})


### PR DESCRIPTION
**What this PR does / why we need it**:
The current checks are obsolete since they're covered by gardenlet - the check introduced by this PR however is needed since it's not covered.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
PR that introduced the gardenlet check: https://github.com/gardener/gardener/pull/7462

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The health check controller was previously checking the health of ManagedResources `extension-shoot-networking-problemdetector-controller-shoot` and `extension-shoot-networking-problemdetector-agent-shoot`. This was redundant as gardenlet already checks and reports the health of ManagedResources with class `shoot` - see https://github.com/gardener/gardener/pull/7462. The health check controller of the extension is adapted to check the health of ManagedResource `extension-shoot-networking-problemdetector-controller-seed`.
```
