### PR TITLE
Fix pipeline_defintions: Bump verify image to golang:1.24.1

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -25,7 +25,7 @@ gardener-extension-shoot-networking-problemdetector:
             we use gosec for sast scanning. See attached log.
     steps:
       verify:
-        image: 'golang:1.23.2'
+        image: 'golang:1.24.1'
     traits:
       component_descriptor:
         ocm_repository: europe-docker.pkg.dev/gardener-project/snapshots


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix pipeline_defintions: Bump verify image to golang:1.24.1

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
