### PR TITLE
Fix roles in `ScrapeConfig`s

### DIFF
--- a/charts/internal/shoot-network-problem-detector-controller-seed/templates/scrapeconfig.yaml
+++ b/charts/internal/shoot-network-problem-detector-controller-seed/templates/scrapeconfig.yaml
@@ -25,7 +25,7 @@ spec:
     namespaces:
       names:
       - kube-system
-    role: endpoints
+    role: Endpoints
     tlsConfig:
       # This is needed because we do not fetch the correct cluster CA bundle right now
       insecureSkipVerify: true


### PR DESCRIPTION
**What this PR does / why we need it**:
Since [`github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring@v0.76.0`](https://github.com/prometheus-operator/prometheus-operator/releases/tag/pkg/apis/monitoring/v0.76.0) only camel case roles are valid in `ScrapeConfig`s of `monitoring.coreos.com/v1alpha1` ([ref](https://github.com/prometheus-operator/prometheus-operator/commit/38900ce#diff-95caef4dacf48c47bf56afc00c513822feba29a5d2f6354b75c97a25a353d52fL75-R77)).
The old lower-case-only roles which are quite common in Gardener components are not valid anymore.

**Which issue(s) this PR fixes**:
Part of https://github.com/gardener/gardener/issues/12401

**Special notes for your reviewer**:

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator

```
