### PR TITLE
Use `autoEnable` field in documentation

### DIFF
--- a/docs/operations/deployment.md
+++ b/docs/operations/deployment.md
@@ -10,7 +10,7 @@ To generally enable the networking problem detector for shoot objects the `shoot
 
 Here it is possible to decide whether the extension should be always available for all shoots or whether the extension must be separately enabled per shoot.
 
-If the extension should be used for all shoots the `globallyEnabled` flag should be set to `true`.
+If the extension should automatically be used for all shoots the `autoEnable` field should be set to `[shoot]`.
 
 ```yaml
 apiVersion: core.gardener.cloud/v1beta1
@@ -20,7 +20,7 @@ spec:
   resources:
     - kind: Extension
       type: shoot-networking-problemdetector
-      globallyEnabled: true
+      autoEnable: [shoot]
 ```
 
 ### ControllerRegistration


### PR DESCRIPTION
**What this PR does / why we need it**:
Use `autoEnable` field in documentation instead of `globallyEnabled` which has been deprecated.

**Special notes for your reviewer**:
/invite @MartinWeindel 

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
