### PR TITLE
Change graphTooltip to shared crosshair

### DIFF
--- a/charts/internal/shoot-network-problem-detector-controller-seed/nwpd-dashboard.json
+++ b/charts/internal/shoot-network-problem-detector-controller-seed/nwpd-dashboard.json
@@ -14,7 +14,7 @@
   },
   "editable": true,
   "gnetId": null,
-  "graphTooltip": 0,
+  "graphTooltip": 1,
   "id": 15,
   "iteration": 1655136035029,
   "links": [],


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- Changes NWPD panel graphTooltip to a shared crosshair
- This helps in analyzing correlated issues on different panels by showing a vertical bar matching the same time as the current panel's mouse position

Looks like this:

<img width="686" height="570" alt="image" src="https://github.com/user-attachments/assets/53845067-edf5-4d88-b065-e1cd82491628" />

 
**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
Network Problem Detector dashboard shows a shared crosshair on all panels now.
```
