### PR TITLE
chore: automerge github actions checkout

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -24,8 +24,8 @@
     {
       // Group golang updates in one PR.
       "groupName": "golang",
-      "matchDatasources": ["docker", "go-version"],
-      "matchPackagePatterns": ["golang"],
+      "matchDatasources": ["docker", "golang-version"],
+      "matchPackagePatterns": ["go","golang"],
       "automerge": true
     },
     {
@@ -36,6 +36,11 @@
         '/^github\\.com/gardener/',
       ],
       "automerge": true
+    },
+    {
+      "matchDatasources": ["github-actions"],
+      "matchPackageNames": ["actions/checkout"],
+      "automerge": true,
     },
     {
       // Ignore paths which most likely create false positives.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- Automatically merge github action updates for the checkout action
- Adjust go updates to also include things like `go toolchain` in go.mod files

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
