### PR TITLE
fix: automerge github actions

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -38,9 +38,12 @@
       "automerge": true
     },
     {
-      "matchDatasources": ["github-actions"],
-      "matchPackageNames": ["actions/checkout"],
-      "automerge": true,
+      "matchManagers": ["github-actions"],
+      "matchPackagePatterns": [
+        "^actions/checkout$",
+        "^actions/setup-go$",
+      ],
+      "automerge": true
     },
     {
       // Ignore paths which most likely create false positives.


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
- Fixes previously not working automatic update of github actions

**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
NONE
```
